### PR TITLE
fix not to insert a line between icon and input box

### DIFF
--- a/assets/stylesheets/selectbox_autocompleter.css
+++ b/assets/stylesheets/selectbox_autocompleter.css
@@ -1,6 +1,9 @@
 .selectbox-autocomplete-span:before {
   content: "\0A0\01f50d"; /* [&nbsp;] and [emoji: Left-Pointing Magnifying Glass] */
 }
+.selectbox-autocomplete-span {
+  white-space: nowrap;
+}
 
 
 #project_quick_jump_box_autocomplete_span:before {


### PR DESCRIPTION
プラグインの"Autocomplete Type"を"insert Textbox with datalist"にした場合に、
虫眼鏡アイコンとインプットボックスの間に改行が入ることがあったので、修正しました。