### PR TITLE
fix multiple selectbox that used custom query of issue

### DIFF
--- a/assets/javascripts/selectbox_autocompleter.js
+++ b/assets/javascripts/selectbox_autocompleter.js
@@ -54,22 +54,24 @@ selectbox_autocompleter.generateSelectboxAutocompleter = function(id) {
     Array.prototype.forEach.call(options, function(option) {
       if(option.textContent.trim() == value.trim()) {
         if (isMultiple) {
+          var needsOnchange = false
           if (!selectbox[option.index].selected) {
-            // Chrome : Scroll to the item set to selectedIndex
-            // Edge   : Scroll to the item last set
-            var selectedOptions = new Array();
-            Array.prototype.forEach.call(options, function(opt) {
-              if (opt.selected) {
-                selectedOptions.push(opt.index);
-              }
-            });
-            selectbox.selectedIndex = option.index; // Chrome scrolls here 
-            Array.prototype.forEach.call(selectedOptions, function(selected) {
-              selectbox[selected].selected = true;
-            });
-            selectbox[option.index].selected = true; // Edge scrolls here
-            if (selectbox.onchange) { selectbox.onchange(); }
+            needsOnchange = true
           }
+          // Chrome : Scroll to the item set to selectedIndex
+          // Edge   : Scroll to the item last set
+          var selectedOptions = new Array();
+          Array.prototype.forEach.call(options, function(opt) {
+            if (opt.selected) {
+              selectedOptions.push(opt.index);
+            }
+          });
+          selectbox.selectedIndex = option.index; // Chrome scrolls here 
+          Array.prototype.forEach.call(selectedOptions, function(selected) {
+            selectbox[selected].selected = true;
+          });
+          selectbox[option.index].selected = true; // Edge scrolls here
+          if (needsOnchange && selectbox.onchange) { selectbox.onchange(); }
         } else {
           if(selectbox.selectedIndex != option.index) {
             selectbox.selectedIndex = option.index;

--- a/assets/javascripts/selectbox_autocompleter.js
+++ b/assets/javascripts/selectbox_autocompleter.js
@@ -50,11 +50,31 @@ selectbox_autocompleter.generateSelectboxAutocompleter = function(id) {
     var self = this;
     var value = self.value;
 
+    var isMultiple = selectbox.hasAttribute('multiple');
     Array.prototype.forEach.call(options, function(option) {
       if(option.textContent.trim() == value.trim()) {
-        if(selectbox.selectedIndex != option.index) {
-          selectbox.selectedIndex = option.index;
-          if (selectbox.onchange) { selectbox.onchange(); }
+        if (isMultiple) {
+          if (!selectbox[option.index].selected) {
+            // Chrome : Scroll to the item set to selectedIndex
+            // Edge   : Scroll to the item last set
+            var selectedOptions = new Array();
+            Array.prototype.forEach.call(options, function(opt) {
+              if (opt.selected) {
+                selectedOptions.push(opt.index);
+              }
+            });
+            selectbox.selectedIndex = option.index; // Chrome scrolls here 
+            Array.prototype.forEach.call(selectedOptions, function(selected) {
+              selectbox[selected].selected = true;
+            });
+            selectbox[option.index].selected = true; // Edge scrolls here
+            if (selectbox.onchange) { selectbox.onchange(); }
+          }
+        } else {
+          if(selectbox.selectedIndex != option.index) {
+            selectbox.selectedIndex = option.index;
+            if (selectbox.onchange) { selectbox.onchange(); }
+          }
         }
         return;
       }


### PR DESCRIPTION
プラグインの"Autocomplete Type"を"insert Textbox with datalist"にした場合の修正です。
チケットのクエリで、担当者などを複数選択に変更できるのですが、
いままでは複数選択にならず選んだ人だけ選択されていたので、
選んだ人を追加で選択するようにしました。

選んだ人が見えるようにスクロールしてほしかったので、
ちょっと複雑なコードになってしまいました。