### PR TITLE
Fixed the selected item may broken layout when list type is jQuery

### DIFF
--- a/assets/stylesheets/selectbox_autocompleter.css
+++ b/assets/stylesheets/selectbox_autocompleter.css
@@ -16,6 +16,7 @@
    border-style: none;
    font-weight: normal;
    color: inherit;
+   margin: 0;
 }
 
 #project_quick_jump_box_autocomplete_span:before {


### PR DESCRIPTION
たびたびすみません。
jQueryリストの時、テキストの長さによっては、選択すると1行で、選択してないと2行になる場合がありました。
ちょっと使い勝手が悪いので、そうならないように修正しました。
マージお願いできますでしょうか。。


**選択してると1行**
![選択してると1行](https://user-images.githubusercontent.com/10005314/60114640-2e196d00-97af-11e9-9f80-7651bb909d1e.png)

**選択してないと2行**
![選択してないと2行](https://user-images.githubusercontent.com/10005314/60114638-2d80d680-97af-11e9-8616-67677547c9fc.png)